### PR TITLE
update redux-thunk to 2.4.2 to silence errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
         "react-toastify": "^8.1.0",
         "readline": "^1.3.0",
         "redux-devtools-extension": "^2.13.9",
-        "redux-thunk": "^2.3.0",
+        "redux-thunk": "^2.4.2",
         "serialize-javascript": "^6.0.0",
         "serve-favicon": "^2.5.0",
         "web-push": "^3.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8956,10 +8956,15 @@ redux-mock-store@^1.5.4:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
-redux-thunk@^2.3.0, redux-thunk@^2.4.1:
+redux-thunk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
+
+redux-thunk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
+  integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
 
 redux@^4.0.0, redux@^4.0.5, redux@^4.1.2:
   version "4.2.0"


### PR DESCRIPTION
## What

Update redux-thunk version

## Why

The current version makes our `yarn lint` fail. This is the reason the CI fails for instance.

## How

I just bumped the version in `package.json` to the latest version available

## Checklist

Have you done all of these things?

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

-   [ ] Documentation added N/A
-   [ ] Tests N/A
-   [ ] TypeScript definitions updated N/A
-   [x] Ready to be merged
