### PR TITLE
Knowledge stats

### DIFF
--- a/src/components/Knowledge/KnowledgeStats.tsx
+++ b/src/components/Knowledge/KnowledgeStats.tsx
@@ -1,0 +1,60 @@
+import React, { memo } from "react"
+import { useSelector } from "react-redux"
+import styles from "./styles.module.scss"
+import { fetchBoxListIfNeed, selectSortedUniqueDetailedBoxes } from "../../store/boxList"
+import {
+    fetchVolunteerDetailedKnowledgeListIfNeed,
+    selectVolunteerDetailedKnowledgeList,
+} from "../../store/volunteerDetailedKnowledgeList"
+import { DetailedBox } from "../../services/boxes"
+import { VolunteerDetailedKnowledge } from "../../services/volunteers"
+
+const KnowledgeStats: React.FC = (): JSX.Element | null => {
+    const detailedBoxes = useSelector(selectSortedUniqueDetailedBoxes) as DetailedBox[]
+    const volunteerDetailedKnowledgeList = useSelector(selectVolunteerDetailedKnowledgeList)
+
+    const knowledgeStats = detailedBoxes.map((box) => ({
+        ok: wiseVolunteersNumber(volunteerDetailedKnowledgeList, box.gameId, "ok"),
+        bof: wiseVolunteersNumber(volunteerDetailedKnowledgeList, box.gameId, "bof"),
+        box,
+    }))
+
+    const unknownGames = knowledgeStats.filter((stat) => stat.ok === 0 && stat.bof === 0)
+
+    return (
+        <div>
+            <p>{unknownGames.length} jeux non connus par des bénévoles :</p>
+            <ul>
+                {knowledgeStats
+                    .filter((stat) => stat.ok === 0 && stat.bof === 0)
+                    .map((stat) => (
+                        <li key={stat.box.id}>
+                            <a
+                                href={`https://boardgamegeek.com/boardgame/${stat.box.bggId}`}
+                                target="_blank"
+                                rel="noreferrer"
+                                className={styles.title}
+                            >
+                                {stat.box.title}
+                            </a>
+                        </li>
+                    ))}
+            </ul>
+        </div>
+    )
+}
+
+function wiseVolunteersNumber(
+    volunteersKnowledge: VolunteerDetailedKnowledge[],
+    gameId: number,
+    wiseness: "ok" | "bof"
+): number {
+    return volunteersKnowledge.filter(
+        (v) =>
+            v[wiseness].includes(gameId) && (v.dayWishes.includes("S") || v.dayWishes.includes("D"))
+    ).length
+}
+
+export default memo(KnowledgeStats)
+
+export const fetchFor = [fetchBoxListIfNeed, fetchVolunteerDetailedKnowledgeListIfNeed]

--- a/src/components/Navigation/MainMenu.tsx
+++ b/src/components/Navigation/MainMenu.tsx
@@ -78,6 +78,7 @@ const MainMenu: FC = (): JSX.Element => {
                 {/* <MenuItem name="Emprunter" pathname="/emprunter" />
                 <MenuItem name="Emprunts" pathname="/emprunts" /> */}
                 <TeamMenuItem team={TEAM_JAV} name="Mes connaissances" pathname="/connaissances" />
+                <TeamMenuItem team={TEAM_JAV} name="Stats" pathname="/connaissancesStats" />
                 <RestrictMenuItem
                     role={ROLES.ASSIGNER}
                     name="Gestion équipes"

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,6 +16,7 @@ import LoginForm from "./LoginForm"
 import KnowledgeBoxList, { fetchFor as fetchForKnowledge } from "./Knowledge/KnowledgeBoxList"
 import KnowledgeCard, { fetchFor as fetchForKnowledgeCard } from "./Knowledge/KnowledgeCard"
 import KnowledgeIntro from "./Knowledge/KnowledgeIntro"
+import KnowledgeStats from "./Knowledge/KnowledgeStats"
 import Asks, { fetchFor as fetchForAsks } from "./Asks"
 import ParticipationDetailsForm, {
     fetchFor as fetchForParticipationDetailsForm,
@@ -46,6 +47,7 @@ export {
     KnowledgeBoxList,
     fetchForKnowledge,
     KnowledgeIntro,
+    KnowledgeStats,
     Loading,
     LoaningIntro,
     Loaning,

--- a/src/pages/KnowledgeStats/KnowledgeStatsPage.tsx
+++ b/src/pages/KnowledgeStats/KnowledgeStatsPage.tsx
@@ -1,0 +1,32 @@
+import { FC, memo } from "react"
+import { useSelector } from "react-redux"
+import { RouteComponentProps } from "react-router-dom"
+import { Helmet } from "react-helmet"
+
+import { AppThunk } from "../../store"
+import styles from "../Knowledge/styles.module.scss"
+import { KnowledgeStats, fetchForKnowledgeCard, LoginForm } from "../../components"
+import { selectUserJwtToken } from "../../store/auth"
+
+export type Props = RouteComponentProps
+
+const KnowledgeStatsPage: FC<Props> = (): JSX.Element => {
+    const jwtToken = useSelector(selectUserJwtToken)
+    if (jwtToken === undefined) return <p>Loading...</p>
+    if (!jwtToken) {
+        return <LoginForm loginNeeded />
+    }
+    return (
+        <div className={styles.knowledgesPage}>
+            <div className={styles.knowledgesContent}>
+                <Helmet title="Stats des jeux connus" />
+                <KnowledgeStats />
+            </div>
+        </div>
+    )
+}
+
+// Fetch server-side data here
+export const loadData = (): AppThunk[] => [...fetchForKnowledgeCard.map((f) => f())]
+
+export default memo(KnowledgeStatsPage)

--- a/src/pages/KnowledgeStats/index.tsx
+++ b/src/pages/KnowledgeStats/index.tsx
@@ -1,0 +1,16 @@
+import loadable from "@loadable/component"
+
+import { Loading, ErrorBoundary } from "../../components"
+import { Props, loadData } from "./KnowledgeStatsPage"
+
+const Knowledges = loadable(() => import("./KnowledgeStatsPage"), {
+    fallback: <Loading />,
+})
+
+export default (props: Props): JSX.Element => (
+    <ErrorBoundary>
+        <Knowledges {...props} />
+    </ErrorBoundary>
+)
+
+export { loadData }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,6 +10,7 @@ import AsyncAnnouncements, { loadData as loadAnnouncementsData } from "../pages/
 import AsyncTeamAssignment, { loadData as loadTeamAssignmentData } from "../pages/TeamAssignment"
 import AsyncRegisterPage, { loadData as loadRegisterPage } from "../pages/Register"
 import AsyncKnowledge, { loadData as loadKnowledgeData } from "../pages/Knowledge"
+import AsyncKnowledgeStats, { loadData as loadKnowledgeStatsData } from "../pages/KnowledgeStats"
 // import AsyncLoans, { loadData as loadLoansData } from "../pages/Loans"
 import AsyncLoaning, { loadData as loadLoaningData } from "../pages/Loaning"
 import AsyncKnowledgeCards, { loadData as loadCardKnowledgeData } from "../pages/KnowledgeCards"
@@ -45,6 +46,11 @@ export default [
                 path: "/connaissances",
                 component: AsyncKnowledge,
                 loadData: loadKnowledgeData,
+            },
+            {
+                path: "/connaissancesStats",
+                component: AsyncKnowledgeStats,
+                loadData: loadKnowledgeStatsData,
             },
             // {
             //     path: "/emprunts",


### PR DESCRIPTION
## What

Add a new page about statistics on games known by JAV team. For now it only contains the list of games not known by anyone (it can be easily updated).

I also added this page, as well as the knowledge page, in the menu, for all people that are in the JAV team.

## Why

Last year Didier felt that this feature, that was present is the old website, was lacking.

## How

I added a new page, much inspired by the KnowledgeCard page.

## Checklist

Have you done all of these things?

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

-   [ ] Documentation added
-   [ ] Tests
-   [ ] TypeScript definitions updated
-   [ ] Ready to be merged
